### PR TITLE
ble-gateway: replace writeFile with writeFileSync

### DIFF
--- a/software/packages/ble-gateway/ble-gateway.js
+++ b/software/packages/ble-gateway/ble-gateway.js
@@ -95,7 +95,7 @@ BleGateway.prototype.on_discover = function (peripheral) {
 
     // We have seen an eddystone packet from the same address
     if (peripheral.id in this._device_to_data) {
-        
+
         // Lookup the correct device to get its parser URL identifier
         var device = this._device_to_data[peripheral.id];
 
@@ -271,7 +271,7 @@ BleGateway.prototype.on_beacon = function (beacon) {
             if (!err) {
                 // Save this URL expansion. OK to just overwrite it each time.
                 this._cached_urls[short_url] = full_url;
-                fs.writeFile('cached_urls.json', JSON.stringify(this._cached_urls));
+                fs.writeFileSync('cached_urls.json', JSON.stringify(this._cached_urls));
 
                 // Create space if this is a new beacon
                 if (!(beacon.id in this._device_to_data)) {
@@ -296,8 +296,8 @@ BleGateway.prototype.on_beacon = function (beacon) {
                         // Store this in the known parsers object
                         this._cached_parsers[request_url] = {};
                         this._cached_parsers[request_url]['parse.js'] = response.body;
-                        fs.writeFile('cached_parsers.json', JSON.stringify(this._cached_parsers));
-                        
+                        fs.writeFileSync('cached_parsers.json', JSON.stringify(this._cached_parsers));
+
                         // Make the downloaded JS an actual function
                         // TODO (2016/01/11): Somehow check if the parser is valid and discard if not.
                         try {


### PR DESCRIPTION
In newer node it's a (somewhat cryptic) error to call an async function
without handling its error. i.e. out of the box this gives:

    $ DEBUG=ble-gateway ./ble-gateway.js --no-nopublish
      ble-gateway Creating a new gateway +0ms
      ble-gateway Found eddystone: 3a5181c22afd4ba7969a43333f1742e1 http://192.168.105.241 +572ms
      ble-gateway Found eddystone: cc99afbd10f14388b027bf203677a0e4 http://128.32.171.51 +891ms
      ble-gateway Fetching http://128.32.171.51/parse.js (cc99afbd10f14388b027bf203677a0e4) +41ms
      ble-gateway Loading parse.js for http://128.32.171.51/ (cc99afbd10f14388b027bf203677a0e4) +92ms
    fs.js:157
      throw new ERR_INVALID_CALLBACK();
      ^

    TypeError [ERR_INVALID_CALLBACK]: Callback must be a function
        at maybeCallback (fs.js:157:9)
        at Object.fs.writeFile (fs.js:1276:14)
        at BleGateway.got_parse_js (/Volumes/code/lab11/gateway/software/packages/ble-gateway/ble-gateway.js:299:28)
        at /Volumes/code/lab11/gateway/software/packages/ble-gateway/node_modules/async/lib/async.js:676:51
        at /Volumes/code/lab11/gateway/software/packages/ble-gateway/node_modules/async/lib/async.js:726:13
        at /Volumes/code/lab11/gateway/software/packages/ble-gateway/node_modules/async/lib/async.js:52:16
        at /Volumes/code/lab11/gateway/software/packages/ble-gateway/node_modules/async/lib/async.js:264:21
        at /Volumes/code/lab11/gateway/software/packages/ble-gateway/node_modules/async/lib/async.js:44:16
        at /Volumes/code/lab11/gateway/software/packages/ble-gateway/node_modules/async/lib/async.js:723:17
        at /Volumes/code/lab11/gateway/software/packages/ble-gateway/node_modules/async/lib/async.js:167:37

Can also resolve by adding an async error handler, but that should then
probably handle the error, and it's not clear how to do that.