### PR TITLE
add power status to collected awair metadata

### DIFF
--- a/software/http-awairlocal-publish/http-awairlocal-publish.js
+++ b/software/http-awairlocal-publish/http-awairlocal-publish.js
@@ -121,8 +121,20 @@ function get_awair_metadata (ipaddress) {
 
             var metadata = {
                 'device_uuid': data.device_uuid,
-                'device_id': device_id,
+                'device_id': device_id
             };
+
+            // If power data is available from the device, store it
+            if(data['power-status'] !== undefined) {
+                if(data['power-status'].battery !== undefined) {
+                    metadata.battery = data['power-status'].battery;
+                }
+                // Manually convert to a "true"/"false" string
+                // to avoid any unexpected input scenarios
+                if(data['power-status'].plugged !== undefined) {
+                    metadata.plugged = data['power-status'].plugged === true ? "true" : "false";
+                }
+            }
 
             // Save metadata to the global table.
             awair_metadata_byip[ipaddress] = metadata;


### PR DESCRIPTION
This change builds upon the existing mechanisms for collecting data from local Awair devices. In addition to the data that is currently captured, we now collect the power status of devices which reported, including battery level and whether the device is plugged in or not.